### PR TITLE
Typo fix "office hour"

### DIFF
--- a/officeHours.py
+++ b/officeHours.py
@@ -1,7 +1,7 @@
 title = "Office Hour"
 print(title)
 
-message = "Office hour are from 9:00 am to 9:00 pm."
+message = "Office Hours are from 9:00 am to 9:00 pm."
 print(message)
 
 portlandTime = 8


### PR DESCRIPTION
Fixing typo. Previously was "Office hour", now "Office Hours"